### PR TITLE
Upgrade passport-oauth to remove deprecated function error

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "main": "./lib/passport-vimeo-oauth2",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "~0.1.1"
+    "passport-oauth": "1.0.0"
   },
   "engines": {
     "node": ">= 0.4.0"


### PR DESCRIPTION
This version of passport-oauth uses the deprecated function createCredentials() which causes the following error:

"createCredentials() is deprecated, use tls.createSecureContext instead"

Upgrading the dependency version to passport-oauth 1.0.0 seems to resolve the issue.
